### PR TITLE
fix: make static Bootstrap asset local

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ A React + TypeScript single-page app built with Webpack and deployed to GitHub P
 ## Prerequisites
 
 - Node.js LTS. This repo includes an `.nvmrc`; if you use `nvm`, run `nvm use`.
-- npm, bundled with Node.js. CI uses `npm ci` with `package-lock.json`.
+- npm, bundled with Node.js. npm is the only supported package manager; commit dependency changes through `package-lock.json`.
 - Git
 
 ## Getting started (local development)
@@ -51,7 +51,7 @@ A React + TypeScript single-page app built with Webpack and deployed to GitHub P
 - `npm run check` – Run typecheck, lint, and format check (used in CI)
 - `npm test` – Run the Jest test suite once
 - `npm run audit` – Audit production dependencies
-- `npm run deploy` – Publish `dist/` to the `gh-pages` branch using `gh-pages`
+- `npm run deploy` – Manually publish `dist/` to the `gh-pages` branch (the automated deployment does not use this script)
 
 ## Building for production
 
@@ -69,14 +69,14 @@ This repo uses GitHub Actions to build and deploy automatically:
 
 - **Build workflow**: `.github/workflows/build.yml` - Runs on pull requests to validate builds
 - **Deploy workflow**: `.github/workflows/deploy.yml` - Runs on pushes to `main` and deploys to GitHub Pages
-- The deploy action runs `npm run build` and then uploads the `dist/` folder to GitHub Pages using the official `actions/deploy-pages@v4` action
+- The deploy workflow runs `npm run build`, uploads `dist/` as a Pages artifact with `actions/upload-pages-artifact`, and deploys that artifact with `actions/deploy-pages`
 
 The deployment process includes:
 
-1. Build validation (typecheck, lint, format check)
+1. Build validation (typecheck, lint, format check) and tests
 2. Production build with static data generation
-3. Upload to GitHub Pages artifact storage
-4. Deploy to the live site
+3. Upload `dist/` to GitHub Pages artifact storage
+4. Deploy the artifact to the `github-pages` environment
 
 You can also deploy locally (requires push access):
 
@@ -87,7 +87,7 @@ npm run deploy
 
 ## Configuration and environment
 
-- Routing uses `react-router-dom` (v6). The dev server is configured with `historyApiFallback` so deep links work locally.
+- Routing uses `react-router-dom` v7. The development server uses `historyApiFallback` for local deep links. In production, GitHub Pages serves `404.html`, which redirects an unknown path into a query-string route that `public/index.html` restores before React Router starts.
 - `webpack.config.ts` reads `HOST` and `PORT` from the environment if set.
 - Static data generation and prerender: At build time, a script fetches recipe metadata and markdown from the recipes-md repo and writes `src/generated/recipes.json` plus `src/generated/meta.json` (tracked upstream SHAs used for incremental builds). When `meta.json` is missing or invalid, generation uses the initial recipes-md commit as the base for the compare API so the diff covers the full repo history. Then, the script uses React SSR (react-dom/server + StaticRouter) to prerender the real app UI to static HTML under `src/generated/static/` (copied to `dist/static/`). The `/static` site is explicitly for no-JavaScript browsers to degrade gracefully, while the SPA continues to work normally.
   - Optional token: To avoid rate limits during generation, set `GITHUB_TOKEN` (or `GH_TOKEN` / `RECIPES_GITHUB_TOKEN`) in your environment.
@@ -126,7 +126,7 @@ src/
 ## Troubleshooting
 
 - Port already in use: set a different `PORT` when starting, e.g. `PORT=4001 npm run start`.
-- Blank page on refresh in production: ensure GitHub Pages is serving the `gh-pages` branch; client-side routing relies on `index.html` being returned for unknown paths.
+- Blank page on refresh in production: confirm the Pages deployment includes both `dist/404.html` and the route-restoration script in `dist/index.html`.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.1.0",
   "license": "MIT",
   "private": true,
+  "packageManager": "npm@12.0.1",
   "homepage": "https://recipes.akofink.com/",
   "dependencies": {
     "bootstrap": "^5.3.8",

--- a/scripts/lib/ssr.ts
+++ b/scripts/lib/ssr.ts
@@ -10,6 +10,8 @@ import type { Recipe } from "./types";
 
 import { STATIC_DIR } from "./io";
 
+const BOOTSTRAP_CSS = require.resolve("bootstrap/dist/css/bootstrap.min.css");
+
 function toRecipeData(recipe: Recipe): RecipeData {
   return {
     name: recipe.name,
@@ -36,7 +38,7 @@ function baseShell(title: string, body: string): string {
   <meta charset=\"utf-8\" />
   <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
   <title>${title}</title>
-  <link href=\"https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css\" rel=\"stylesheet\">
+  <link href=\"/static/bootstrap.min.css\" rel=\"stylesheet\">
   <style>
     body { height: 100%; }
     .clean-link { text-decoration: none; color: inherit; }
@@ -89,6 +91,10 @@ export async function writeStatic(recipes: Recipe[]): Promise<void> {
   indexBody = rewriteLocalLinksToStatic(indexBody);
   const indexShell = baseShell("Recipes", indexBody);
   await fs.promises.mkdir(STATIC_DIR, { recursive: true });
+  await fs.promises.copyFile(
+    BOOTSTRAP_CSS,
+    path.join(STATIC_DIR, "bootstrap.min.css"),
+  );
   await fs.promises.writeFile(
     path.join(STATIC_DIR, "index.html"),
     indexShell,


### PR DESCRIPTION
## Summary

- Serve generated no-JavaScript pages with Bootstrap CSS copied from the installed npm dependency.
- Document React Router 7 routing and GitHub Pages artifact deployment.
- Declare npm as the package manager and ignore stray Yarn lockfiles.

## Testing

- `npm run check`
- `npm test`
- `npm run build`
- Confirmed generated static HTML references `/static/bootstrap.min.css` and the source asset matches the installed Bootstrap CSS.

Fixes #40
