### PR TITLE
Improve generated recipe reliability

### DIFF
--- a/scripts/lib/generate.ts
+++ b/scripts/lib/generate.ts
@@ -21,6 +21,7 @@ import { markdownToHtml, withHtmlFromMarkdown } from "./markdown";
 import type { GenerationMeta, GhCompare, GhCompareFile, Recipe } from "./types";
 
 const INITIAL_BASE_SHA = "c9928c5c993d30c8c77b17966505c05a2242df6c";
+const MAX_COMPARE_FILES = 300;
 
 type ChangedRecipeEntry = {
   filename: string;
@@ -129,7 +130,12 @@ export async function diffChanges(
       compareCommits(baseImagesSha, imagesSha),
     ]);
 
-  if (!Array.isArray(recipesCmp?.files) || !Array.isArray(imagesCmp?.files)) {
+  if (
+    !Array.isArray(recipesCmp?.files) ||
+    !Array.isArray(imagesCmp?.files) ||
+    recipesCmp.files.length >= MAX_COMPARE_FILES ||
+    imagesCmp.files.length >= MAX_COMPARE_FILES
+  ) {
     throw new Error("Compare response did not include a complete file list.");
   }
 

--- a/scripts/lib/generate.ts
+++ b/scripts/lib/generate.ts
@@ -12,6 +12,7 @@ import {
   latestCommitShaForPath,
   branchHeadSha,
   compareCommits,
+  listRecipes,
   listImagesFor,
   fetchMarkdown,
 } from "./github";
@@ -128,6 +129,10 @@ export async function diffChanges(
       compareCommits(baseImagesSha, imagesSha),
     ]);
 
+  if (!Array.isArray(recipesCmp?.files) || !Array.isArray(imagesCmp?.files)) {
+    throw new Error("Compare response did not include a complete file list.");
+  }
+
   const changedRecipeFiles: Set<ChangedRecipeEntry> = new Set(
     (recipesCmp?.files || [])
       .filter(
@@ -150,6 +155,29 @@ export async function diffChanges(
   );
 
   return { changedRecipeFiles, changedImageRecipeNames };
+}
+
+/** Build the complete recipe set from the authoritative upstream directory. */
+export async function fullGeneration(): Promise<Recipe[]> {
+  const upstreamRecipes = await listRecipes();
+  const recipes: Recipe[] = [];
+
+  for (const { filename, name } of upstreamRecipes) {
+    const [markdown, images] = await Promise.all([
+      fetchMarkdown(filename),
+      listImagesFor(name),
+    ]);
+    recipes.push({
+      name,
+      filename,
+      imageName: images[0] || null,
+      imageNames: images,
+      markdown,
+      html: markdown ? await markdownToHtml(markdown) : "",
+    });
+  }
+
+  return recipes.sort((a, b) => a.name.localeCompare(b.name));
 }
 
 /**
@@ -265,15 +293,8 @@ export async function run(): Promise<void> {
 
   if (outFileExists && isUpToDate(localMeta, recipesSha, imagesSha)) {
     console.log("[generate-static-data] Up to date. Skipping generation.");
-    try {
-      const { writeStatic } = await import("./ssr");
-      await writeStatic(await withHtmlFromMarkdown(localRecipes || []));
-    } catch (e: unknown) {
-      console.warn(
-        "[generate-static-data] Writing static pages from local data failed:",
-        e instanceof Error ? e.message : String(e),
-      );
-    }
+    const { writeStatic } = await import("./ssr");
+    await writeStatic(await withHtmlFromMarkdown(localRecipes || []));
     return;
   }
 
@@ -328,11 +349,28 @@ export async function run(): Promise<void> {
       await writeMetaNow(recipesSha, imagesSha, seedRecipes.length);
     }
     return;
-  } catch (e: unknown) {
-    if (process.env.CI) {
-      const msg = e instanceof Error ? e.message : String(e);
-      throw new Error(`[generate-static-data] Update failed in CI: ${msg}`);
+  } catch (compareError: unknown) {
+    console.warn(
+      "[generate-static-data] Incremental update failed; rebuilding from the upstream recipe list:",
+      compareError instanceof Error
+        ? compareError.message
+        : String(compareError),
+    );
+    try {
+      const rebuilt = await fullGeneration();
+      await writeRecipes(rebuilt);
+      const { writeStatic } = await import("./ssr");
+      await writeStatic(rebuilt);
+      await writeMetaNow(recipesSha, imagesSha, rebuilt.length);
+      console.log(
+        `[generate-static-data] Full rebuild complete. Wrote ${OUT_FILE} and ${META_FILE}`,
+      );
+    } catch (rebuildError: unknown) {
+      const msg =
+        rebuildError instanceof Error
+          ? rebuildError.message
+          : String(rebuildError);
+      throw new Error(`[generate-static-data] Full rebuild failed: ${msg}`);
     }
-    throw e;
   }
 }

--- a/scripts/lib/github.ts
+++ b/scripts/lib/github.ts
@@ -123,7 +123,11 @@ export async function listRecipes(): Promise<
 > {
   const url = `${CONTENTS_BASE}/recipes`;
   const items: GhContentItem[] | null = await fetchJson<GhContentItem[]>(url);
-  if (!Array.isArray(items)) return [];
+  if (!Array.isArray(items)) {
+    throw new Error(
+      `Unable to list upstream recipes: ${JSON.stringify(items)}`,
+    );
+  }
   return items
     .filter(
       (it) => it && typeof it.name === "string" && it.name.endsWith(".md"),

--- a/scripts/lib/ssr.ts
+++ b/scripts/lib/ssr.ts
@@ -71,6 +71,8 @@ export async function writeStatic(recipes: Recipe[]): Promise<void> {
     Record<string, unknown>
   >;
 
+  const pages = new Map<string, string>();
+
   // Index
   const indexTree: ReactElement = React.createElement(
     StaticRouterCT,
@@ -90,16 +92,7 @@ export async function writeStatic(recipes: Recipe[]): Promise<void> {
   let indexBody = jsx(indexTree);
   indexBody = rewriteLocalLinksToStatic(indexBody);
   const indexShell = baseShell("Recipes", indexBody);
-  await fs.promises.mkdir(STATIC_DIR, { recursive: true });
-  await fs.promises.copyFile(
-    BOOTSTRAP_CSS,
-    path.join(STATIC_DIR, "bootstrap.min.css"),
-  );
-  await fs.promises.writeFile(
-    path.join(STATIC_DIR, "index.html"),
-    indexShell,
-    "utf8",
-  );
+  pages.set("index.html", indexShell);
 
   // Per-recipe pages
   for (const r of recipes) {
@@ -121,8 +114,26 @@ export async function writeStatic(recipes: Recipe[]): Promise<void> {
     let body = jsx(recipeTree);
     body = rewriteLocalLinksToStatic(body);
     const shell = baseShell(`${r.name} – Recipes`, body);
-    const dir = path.join(STATIC_DIR, r.name);
-    await fs.promises.mkdir(dir, { recursive: true });
-    await fs.promises.writeFile(path.join(dir, "index.html"), shell, "utf8");
+    pages.set(path.join(r.name, "index.html"), shell);
+  }
+
+  const stagingDir = `${STATIC_DIR}.tmp`;
+  await fs.promises.rm(stagingDir, { recursive: true, force: true });
+  try {
+    await fs.promises.mkdir(stagingDir, { recursive: true });
+    await fs.promises.copyFile(
+      BOOTSTRAP_CSS,
+      path.join(stagingDir, "bootstrap.min.css"),
+    );
+    for (const [relativePath, contents] of Array.from(pages.entries())) {
+      const outputPath = path.join(stagingDir, relativePath);
+      await fs.promises.mkdir(path.dirname(outputPath), { recursive: true });
+      await fs.promises.writeFile(outputPath, contents, "utf8");
+    }
+    await fs.promises.rm(STATIC_DIR, { recursive: true, force: true });
+    await fs.promises.rename(stagingDir, STATIC_DIR);
+  } catch (error) {
+    await fs.promises.rm(stagingDir, { recursive: true, force: true });
+    throw error;
   }
 }

--- a/src/generator.test.ts
+++ b/src/generator.test.ts
@@ -34,6 +34,20 @@ test("rejects compare responses without file lists", async () => {
   );
 });
 
+test("rejects compare responses at GitHub's file truncation limit", async () => {
+  mockedCompareCommits
+    .mockResolvedValueOnce({
+      files: Array.from({ length: 300 }, (_, index) => ({
+        filename: `recipes/recipe-${index}.md`,
+      })),
+    })
+    .mockResolvedValueOnce({ files: [] });
+
+  await expect(diffChanges("old", "old", "new", "new")).rejects.toThrow(
+    "complete file list",
+  );
+});
+
 test("full generation uses only recipes in the upstream directory", async () => {
   mockedListRecipes.mockResolvedValue([
     { filename: "renamed.md", name: "renamed" },

--- a/src/generator.test.ts
+++ b/src/generator.test.ts
@@ -1,0 +1,52 @@
+import { diffChanges, fullGeneration } from "../scripts/lib/generate";
+import {
+  compareCommits,
+  fetchMarkdown,
+  listImagesFor,
+  listRecipes,
+} from "../scripts/lib/github";
+
+jest.mock("../scripts/lib/github", () => ({
+  branchHeadSha: jest.fn(),
+  compareCommits: jest.fn(),
+  fetchMarkdown: jest.fn(),
+  latestCommitShaForPath: jest.fn(),
+  listImagesFor: jest.fn(),
+  listRecipes: jest.fn(),
+}));
+jest.mock("../scripts/lib/markdown", () => ({
+  markdownToHtml: jest.fn(async (markdown: string) => `<h1>${markdown}</h1>`),
+  withHtmlFromMarkdown: jest.fn(),
+}));
+
+const mockedCompareCommits = jest.mocked(compareCommits);
+const mockedFetchMarkdown = jest.mocked(fetchMarkdown);
+const mockedListImagesFor = jest.mocked(listImagesFor);
+const mockedListRecipes = jest.mocked(listRecipes);
+
+test("rejects compare responses without file lists", async () => {
+  mockedCompareCommits
+    .mockResolvedValueOnce({ files: [{ filename: "recipes/new.md" }] })
+    .mockResolvedValueOnce({});
+
+  await expect(diffChanges("old", "old", "new", "new")).rejects.toThrow(
+    "complete file list",
+  );
+});
+
+test("full generation uses only recipes in the upstream directory", async () => {
+  mockedListRecipes.mockResolvedValue([
+    { filename: "renamed.md", name: "renamed" },
+  ]);
+  mockedFetchMarkdown.mockResolvedValue("# Renamed");
+  mockedListImagesFor.mockResolvedValue(["finished.jpg"]);
+
+  await expect(fullGeneration()).resolves.toEqual([
+    expect.objectContaining({
+      filename: "renamed.md",
+      name: "renamed",
+      imageName: "finished.jpg",
+      markdown: "# Renamed",
+    }),
+  ]);
+});

--- a/src/github.test.ts
+++ b/src/github.test.ts
@@ -1,0 +1,24 @@
+/** @jest-environment node */
+
+import { listRecipes } from "../scripts/lib/github";
+
+afterEach(() => {
+  jest.restoreAllMocks();
+});
+
+test("distinguishes a failed recipe listing from an empty directory", async () => {
+  jest
+    .spyOn(global, "fetch")
+    .mockResolvedValueOnce(new Response(null, { status: 404 }))
+    .mockResolvedValueOnce(
+      new Response("[]", {
+        status: 200,
+        headers: { "content-type": "application/json" },
+      }),
+    );
+
+  await expect(listRecipes()).rejects.toThrow(
+    "Unable to list upstream recipes",
+  );
+  await expect(listRecipes()).resolves.toEqual([]);
+});

--- a/src/ssr.test.ts
+++ b/src/ssr.test.ts
@@ -44,9 +44,22 @@ test("replaces static output so deleted and renamed recipes do not remain", asyn
       "utf8",
     ),
   ).resolves.toContain("new-name");
+  await expect(
+    Promise.all([
+      fs.promises.readFile(path.join(mockStaticDir, "index.html"), "utf8"),
+      fs.promises.readFile(
+        path.join(mockStaticDir, "bootstrap.min.css"),
+        "utf8",
+      ),
+    ]),
+  ).resolves.toEqual([
+    expect.stringContaining("/static/bootstrap.min.css"),
+    expect.stringMatching(/.+/),
+  ]);
 });
 
 test("keeps existing output when rendering fails", async () => {
+  jest.spyOn(console, "error").mockImplementation(() => undefined);
   await writeStatic([recipe("existing")]);
   const invalidRecipe = recipe("invalid");
   invalidRecipe.name = Symbol("invalid") as unknown as string;

--- a/src/ssr.test.ts
+++ b/src/ssr.test.ts
@@ -1,0 +1,58 @@
+/** @jest-environment node */
+
+import fs from "fs";
+import path from "path";
+import type { Recipe } from "../scripts/lib/types";
+
+jest.mock("../scripts/lib/io", () => ({
+  STATIC_DIR: `${process.env.TMPDIR || "/tmp"}/recipes-ui-ssr-${process.pid}`,
+}));
+
+import { writeStatic } from "../scripts/lib/ssr";
+
+const mockStaticDir = `${process.env.TMPDIR || "/tmp"}/recipes-ui-ssr-${process.pid}`;
+
+function recipe(name: string): Recipe {
+  return {
+    name,
+    filename: `${name}.md`,
+    imageName: null,
+    imageNames: [],
+    markdown: `# ${name}`,
+    html: `<h1>${name}</h1>`,
+  };
+}
+
+afterEach(async () => {
+  await fs.promises.rm(mockStaticDir, { recursive: true, force: true });
+  await fs.promises.rm(`${mockStaticDir}.tmp`, {
+    recursive: true,
+    force: true,
+  });
+});
+
+test("replaces static output so deleted and renamed recipes do not remain", async () => {
+  await writeStatic([recipe("old-name")]);
+  await writeStatic([recipe("new-name")]);
+
+  await expect(
+    fs.promises.access(path.join(mockStaticDir, "old-name", "index.html")),
+  ).rejects.toThrow();
+  await expect(
+    fs.promises.readFile(
+      path.join(mockStaticDir, "new-name", "index.html"),
+      "utf8",
+    ),
+  ).resolves.toContain("new-name");
+});
+
+test("keeps existing output when rendering fails", async () => {
+  await writeStatic([recipe("existing")]);
+  const invalidRecipe = recipe("invalid");
+  invalidRecipe.name = Symbol("invalid") as unknown as string;
+
+  await expect(writeStatic([invalidRecipe])).rejects.toThrow();
+  await expect(
+    fs.promises.access(path.join(mockStaticDir, "existing", "index.html")),
+  ).resolves.toBeUndefined();
+});


### PR DESCRIPTION
## Summary

- Rebuild recipes from the authoritative upstream directory when compare responses omit file data.
- Treat compare responses at GitHub's 300-file limit as incomplete and reject failed upstream recipe listings.
- Replace generated static output through a staging directory so deleted and renamed recipe pages cannot remain.
- Include the local Bootstrap stylesheet in the same atomic static-output replacement.
- Propagate SSR and rebuild failures instead of allowing stale output to deploy.
- Add focused generator and SSR regression tests.

## Testing

- `npm test -- --runInBand`
- `npm run check`
- `npm run build`

Fixes #37