### PR TITLE
ci: use trusted action major tags

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,15 +13,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "24"
           cache: "npm"
       - name: Cache generated recipes data
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@v4
         with:
           path: src/generated/
           key: ${{ runner.os }}-node-24-generated-${{ hashFiles('package-lock.json', 'scripts/generate-static-data.js') }}-${{ github.run_id }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,22 +17,22 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+      - uses: actions/checkout@v4
         with:
           persist-credentials: false
-      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+      - uses: actions/setup-node@v4
         with:
           node-version: "24"
           cache: "npm"
       - name: Cache generated recipes data
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@v4
         with:
           path: src/generated/
           key: ${{ runner.os }}-node-24-generated-${{ hashFiles('package-lock.json', 'scripts/generate-static-data.js') }}-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-node-24-generated-${{ hashFiles('package-lock.json', 'scripts/generate-static-data.js') }}-
       - name: Setup Pages
-        uses: actions/configure-pages@983d7736d9b0ae728b81ab479565c72886d7745b # v5
+        uses: actions/configure-pages@v5
       - name: Install
         run: npm ci
       - name: Audit production dependencies
@@ -46,7 +46,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: npm run build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+        uses: actions/upload-pages-artifact@v3
         with:
           path: ./dist
   deploy:
@@ -61,4 +61,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary

- Replace immutable GitHub Actions commit references with repository-trusted major release tags.
- Preserve Node 24, generated-data caching, least-privilege permissions, and checkout credential handling.

## Verification

- `npm run check`
- `npm test`
- `npm run audit`
- `npx prettier --check .github/workflows/build.yml .github/workflows/deploy.yml`
- `uvx zizmor --no-exit-codes .github/workflows/build.yml .github/workflows/deploy.yml` reports only the intentionally adopted major-tag references.

Fixes #47
