### PR TITLE
ci: #57 update GitHub Actions to Node.js 24 versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -13,16 +13,16 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v5
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
       - name: Cache generated recipes data
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: src/generated/
           key: ${{ runner.os }}-node-24-generated-${{ hashFiles('pnpm-lock.yaml', 'scripts/generate-static-data.js') }}-${{ github.run_id }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,23 +17,23 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           persist-credentials: false
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v5
         with:
           node-version-file: ".nvmrc"
           cache: "pnpm"
       - name: Cache generated recipes data
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: src/generated/
           key: ${{ runner.os }}-node-24-generated-${{ hashFiles('pnpm-lock.yaml', 'scripts/generate-static-data.js') }}-${{ github.run_id }}
           restore-keys: |
             ${{ runner.os }}-node-24-generated-${{ hashFiles('pnpm-lock.yaml', 'scripts/generate-static-data.js') }}-
       - name: Setup Pages
-        uses: actions/configure-pages@v5
+        uses: actions/configure-pages@v6
       - name: Install
         run: pnpm install --frozen-lockfile
       - name: Audit production dependencies
@@ -47,7 +47,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: pnpm run build
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./dist
   deploy:
@@ -62,4 +62,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Summary

Updates the GitHub Actions used by the Build and Deploy workflows to the first major releases that officially target Node.js 24, eliminating the Node.js 20 deprecation annotations reported in run 31339057139. All action inputs and workflow behavior are preserved.

| Action | Old | New | Node runtime |
| --- | --- | --- | --- |
| `actions/checkout` | v4 | v5 | node24 |
| `pnpm/action-setup` | v4 | v5 | node24 |
| `actions/setup-node` | v4 | v5 | node24 |
| `actions/cache` | v4 | v5 | node24 |
| `actions/configure-pages` | v5 | v6 | node24 |
| `actions/upload-pages-artifact` | v3 | v5 | node24 (internally uses `actions/upload-artifact` v7) |
| `actions/deploy-pages` | v4 | v5 | node24 |

Notes:

- `actions/upload-pages-artifact` skips v4 because it still pins `actions/upload-artifact` v4.6.2 (Node.js 20) internally; v5 pins `actions/upload-artifact` v7.0.0 (Node.js 24).
- The action versions previously reported in the run warnings but no longer present in the workflows (`pnpm/action-setup` was already upgraded here; direct `actions/upload-artifact` usage was internal to `upload-pages-artifact`) are covered by the table above.

fixes #57